### PR TITLE
Add Report Portal launch URL when it's finished

### DIFF
--- a/src/ReportPortal.VSTest.TestLogger/ReportPortalLogger.cs
+++ b/src/ReportPortal.VSTest.TestLogger/ReportPortalLogger.cs
@@ -466,6 +466,7 @@ namespace ReportPortal.VSTest.TestLogger
 
                     stopwatch.Stop();
                     Console.WriteLine($" Sync time: {stopwatch.Elapsed}");
+                    Console.WriteLine($"Report Portal results at: {_launchReporter.Info.Url}");
 
                     var statisticsRecord = _launchReporter.StatisticsCounter.ToString();
                     TraceLogger.Info(statisticsRecord);

--- a/src/ReportPortal.VSTest.TestLogger/ReportPortalLogger.cs
+++ b/src/ReportPortal.VSTest.TestLogger/ReportPortalLogger.cs
@@ -464,7 +464,7 @@ namespace ReportPortal.VSTest.TestLogger
                     }
 
                     stopwatch.Stop();
-                    Console.WriteLine($"Successfully sent at {_sender.LaunchReporter.Info.Url} Elapsed: {stopwatch.Elapsed}");
+                    Console.WriteLine($"Successfully sent at {_launchReporter.Info.Url} Elapsed: {stopwatch.Elapsed}");
 
                     var statisticsRecord = _launchReporter.StatisticsCounter.ToString();
                     TraceLogger.Info(statisticsRecord);

--- a/src/ReportPortal.VSTest.TestLogger/ReportPortalLogger.cs
+++ b/src/ReportPortal.VSTest.TestLogger/ReportPortalLogger.cs
@@ -452,7 +452,6 @@ namespace ReportPortal.VSTest.TestLogger
                     _launchReporter.Finish(requestFinishLaunch);
 
                     Stopwatch stopwatch = Stopwatch.StartNew();
-                    Console.Write("Finishing to send results to Report Portal...");
 
                     try
                     {
@@ -465,8 +464,7 @@ namespace ReportPortal.VSTest.TestLogger
                     }
 
                     stopwatch.Stop();
-                    Console.WriteLine($" Sync time: {stopwatch.Elapsed}");
-                    Console.WriteLine($"Report Portal results at: {_launchReporter.Info.Url}");
+                    Console.WriteLine($"Successfully sent at {_sender.LaunchReporter.Info.Url} Elapsed: {stopwatch.Elapsed}");
 
                     var statisticsRecord = _launchReporter.StatisticsCounter.ToString();
                     TraceLogger.Info(statisticsRecord);


### PR DESCRIPTION
This report URL will be available right after saving the report. It's quite convenient to get the URL in logs, you don't need to look at the report in the dashboard. Just follow the link from the logs